### PR TITLE
Add minimal game engine skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-# Google App Engine generated folder
-appengine-generated/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # Coreria
-A game engine
+
+A tiny starter game engine inspired by the Epoch of Elria project.  The
+engine provides a minimal :class:`Engine` and :class:`Entity` that manage a
+basic update/render loop.  See ``main.py`` for a short example and the
+``tests`` directory for usage examples.

--- a/elria/__init__.py
+++ b/elria/__init__.py
@@ -1,0 +1,11 @@
+"""Core package for the Epoch of Elria game engine.
+
+This package exposes the :class:`Engine` and :class:`Entity` classes
+for building simple games or simulations.  The implementation is kept
+intentionally small so it can serve as a starting point for a more
+feature rich engine.
+"""
+
+from .engine import Engine, Entity
+
+__all__ = ["Engine", "Entity"]

--- a/elria/engine.py
+++ b/elria/engine.py
@@ -1,0 +1,83 @@
+"""A tiny but functional game engine skeleton.
+
+The goal is to provide a cohesive entry point that ties together the
+update and render loops.  It is intentionally minimal but demonstrates
+how entities can be managed by the engine.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import List
+
+
+class Entity:
+    """Basic object that can be processed by the :class:`Engine`.
+
+    Sub‑classes are expected to override :meth:`update` and optionally
+    :meth:`render` to provide game specific behaviour.
+    """
+
+    def update(self, dt: float) -> None:  # pragma: no cover - default no-op
+        """Advance the entity's state.
+
+        Parameters
+        ----------
+        dt:
+            The elapsed time since the previous tick, in seconds.
+        """
+
+    def render(self) -> None:  # pragma: no cover - default no-op
+        """Render the entity.  For this starter engine we simply provide a
+        placeholder method that can be extended by consumers."""
+
+
+class Engine:
+    """Drive updates and rendering for a collection of entities."""
+
+    def __init__(self) -> None:
+        self._entities: List[Entity] = []
+        self._running: bool = False
+
+    # ------------------------------------------------------------------
+    def add_entity(self, entity: Entity) -> None:
+        """Register *entity* with the engine."""
+
+        self._entities.append(entity)
+
+    # ------------------------------------------------------------------
+    def tick(self, dt: float) -> None:
+        """Advance the simulation by *dt* seconds."""
+
+        for entity in list(self._entities):
+            entity.update(dt)
+            entity.render()
+
+    # ------------------------------------------------------------------
+    def run(self, duration: float = 1.0, tick_rate: float = 60.0) -> None:
+        """Run the engine for ``duration`` seconds.
+
+        The engine repeatedly calls :meth:`tick` at ``tick_rate`` frames per
+        second, sleeping in-between calls.  The method returns once the
+        requested duration has elapsed.
+        """
+
+        self._running = True
+        dt = 1.0 / tick_rate
+        elapsed = 0.0
+
+        while self._running and elapsed < duration:
+            start = time.time()
+            self.tick(dt)
+            sleep_time = dt - (time.time() - start)
+            if sleep_time > 0:
+                time.sleep(sleep_time)
+            elapsed += dt
+
+        self._running = False
+
+    # ------------------------------------------------------------------
+    def stop(self) -> None:
+        """Request that the running engine exits its loop."""
+
+        self._running = False

--- a/main.py
+++ b/main.py
@@ -1,0 +1,25 @@
+"""Example entry point that wires together the engine components."""
+
+from __future__ import annotations
+
+from elria import Engine, Entity
+
+
+class Player(Entity):
+    """Minimal example entity that counts how often it is updated."""
+
+    def __init__(self) -> None:
+        self.counter = 0
+
+    def update(self, dt: float) -> None:  # pragma: no cover - example code
+        self.counter += 1
+        print(f"tick {self.counter}: dt={dt:.3f}")
+
+    def render(self) -> None:  # pragma: no cover - example code
+        pass
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    engine = Engine()
+    engine.add_entity(Player())
+    engine.run(duration=0.2, tick_rate=5)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,37 @@
+import time
+
+from elria import Engine, Entity
+
+
+class Dummy(Entity):
+    def __init__(self) -> None:
+        self.updated = 0
+
+    def update(self, dt: float) -> None:
+        self.updated += 1
+
+    def render(self) -> None:
+        pass
+
+
+def test_tick_updates_entities():
+    engine = Engine()
+    dummy = Dummy()
+    engine.add_entity(dummy)
+
+    engine.tick(0.1)
+
+    assert dummy.updated == 1
+
+
+def test_run_advances_time_quickly():
+    engine = Engine()
+    dummy = Dummy()
+    engine.add_entity(dummy)
+
+    start = time.time()
+    engine.run(duration=0.05, tick_rate=20)
+    elapsed = time.time() - start
+
+    assert dummy.updated > 0
+    assert elapsed >= 0.05


### PR DESCRIPTION
## Summary
- add `Engine` and `Entity` classes to tie update/render loop
- include example entry point and tests
- ignore Python bytecode

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb2b0609d88323b3f17b39be01037b